### PR TITLE
feat: add light and dark theme support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "i18n": "^0.15.1",
         "next": "15.3.3",
         "next-intl": "^4.1.0",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-datepicker": "^8.4.0",
         "react-dom": "^19.0.0",
@@ -1945,6 +1946,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n": "^0.15.1",
     "next": "15.3.3",
     "next-intl": "^4.1.0",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-datepicker": "^8.4.0",
     "react-dom": "^19.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,22 +4,23 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
+  --background: #f4f0ff;
   --foreground: #171717;
+  --primary: #4f46e5;
+}
+
+.dark {
+  --background: #04000e;
+  --foreground: #ededed;
+  --primary: #4f46e5;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {
@@ -29,9 +30,9 @@ body {
 }
 
 .input {
-  @apply border border-gray-300 rounded px-3 py-2 w-full text-sm;
+  @apply border border-gray-300 dark:border-gray-600 rounded px-3 py-2 w-full text-sm bg-background text-foreground;
 }
 
 .btn {
-  @apply bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded;
+  @apply bg-primary hover:opacity-90 text-white font-semibold py-2 px-4 rounded;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import LocaleSwitcher from '@/components/LocaleSwitcher';
+import ThemeProvider from '@/components/ThemeProvider';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -30,14 +32,17 @@ export default async function RootLayout({
   const locale = await getLocale();
 
   return (
-    <html lang={locale}>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <NextIntlClientProvider>
-          <LocaleSwitcher />
-          {children}
-        </NextIntlClientProvider>
+    <html lang={locale} suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          <NextIntlClientProvider>
+            <div className="flex justify-end gap-2 p-4">
+              <LocaleSwitcher />
+              <ThemeToggle />
+            </div>
+            {children}
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,12 +22,12 @@ export default function HomePage() {
   const specificLocale = locale === 'ko' ? 'ko' : locale === 'ja' ? 'ja' : 'en';
 
   return (
-    <main className='min-h-screen bg-gradient-to-b from-white to-slate-100 px-4 py-10 text-center'>
+    <main className='min-h-screen bg-background text-foreground px-4 py-10 text-center transition-colors'>
       <div className='max-w-2xl mx-auto'>
-        <h1 className='text-3xl md:text-5xl font-bold mb-4 text-gray-800'>
+        <h1 className='text-3xl md:text-5xl font-bold mb-4'>
           {`📅 ${t('title')}`}
         </h1>
-        <p className='text-gray-600 mb-10 text-sm md:text-base'>
+        <p className='mb-10 text-sm md:text-base opacity-80'>
           Create a calendar file (.ics) for your events. Supports English,
           日本語 & 한국어.
         </p>
@@ -41,7 +41,7 @@ export default function HomePage() {
         {/* <EventList events={events} onRemove={handleRemove} /> */}
         <DownloadButton events={events} />
 
-        <footer className='mt-16 text-xs text-gray-400'>
+        <footer className='mt-16 text-xs opacity-60'>
           Made by Yunsu Bae - 다국어 지원 테스트 중
         </footer>
       </div>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import { ReactNode } from 'react';
+
+export default function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <button onClick={toggleTheme} className="p-2 border rounded text-sm">
+      {theme === 'dark' ? 'Light' : 'Dark'}
+    </button>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    './app/**/*.{js,ts,jsx,tsx}', // 앱 디렉터리 기준
-    './components/**/*.{js,ts,jsx,tsx}'
+    './src/**/*.{js,ts,jsx,tsx}'
   ],
+  darkMode: 'class',
   theme: {
     extend: {
-      // 필요 시 원하는 디자인 확장 가능
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        primary: 'var(--primary)'
+      }
     }
   },
-  plugins: [
-    // Forms, Typography 등 공식 플러그인 예: require('@tailwindcss/forms')
-  ]
+  plugins: []
 };


### PR DESCRIPTION
## Summary
- add theme provider and toggle for light/dark modes
- introduce configurable primary colors and Tailwind dark mode
- apply new theme variables across the app

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Parameter 'e' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6899f610d84c8325bcf10b58898ef5c4