### PR TITLE
feat(ui): modernize layout and improve mobile design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,10 +29,29 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.4s ease both;
+}
+
 .input {
-  @apply border border-gray-300 dark:border-gray-600 rounded px-3 py-2 w-full text-sm bg-background text-foreground;
+  @apply border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 w-full text-sm bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 transition;
 }
 
 .btn {
-  @apply bg-primary hover:opacity-90 text-white font-semibold py-2 px-4 rounded;
+  @apply bg-primary hover:bg-primary/90 text-white font-semibold py-2 px-4 rounded-lg transition-colors;
+}
+
+.card {
+  @apply bg-background/80 backdrop-blur border border-primary/20 rounded-2xl shadow-lg;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,12 +19,10 @@ export default function HomePage() {
   };
 
   return (
-    <main className='min-h-screen bg-background text-foreground px-4 py-10 text-center transition-colors'>
-      <div className='max-w-2xl mx-auto'>
-        <h1 className='text-3xl md:text-5xl font-bold mb-4'>
-          {`📅 ${t('title')}`}
-        </h1>
-        <p className='mb-10 text-sm md:text-base opacity-80'>
+    <main className='min-h-screen bg-gradient-to-br from-background to-primary/10 text-foreground px-4 py-10 transition-colors flex items-center justify-center'>
+      <div className='w-full max-w-2xl space-y-8 text-center animate-fade-in'>
+        <h1 className='text-3xl md:text-5xl font-bold'>{`📅 ${t('title')}`}</h1>
+        <p className='text-sm md:text-base opacity-80'>
           Create a calendar file (.ics) for your events. Supports English,
           日本語 & 한국어.
         </p>
@@ -36,7 +34,7 @@ export default function HomePage() {
         />
         <DownloadButton events={events} />
 
-        <footer className='mt-16 text-xs opacity-60'>
+        <footer className='pt-6 text-xs opacity-60'>
           Made by Yunsu Bae - 다국어 지원 테스트 중
         </footer>
       </div>

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -20,7 +20,7 @@ export default function DownloadButton({ events }: Props) {
       <button
         onClick={handleDownload}
         disabled={events.length === 0}
-        className='btn disabled:opacity-50'
+        className='btn rounded-full px-6 py-3 text-sm md:text-base shadow-md hover:shadow-lg transition disabled:opacity-50'
       >
         Download Calendar
       </button>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -59,11 +59,11 @@ export default function EventForm({
   };
 
   return (
-    <div className='max-w-2xl mx-auto p-8 bg-background text-foreground rounded-2xl shadow-lg border border-primary/20 space-y-6'>
+    <div className='card p-6 sm:p-8 space-y-6 animate-fade-in'>
       <div className='flex justify-end'>
         <button
           onClick={() => setManualMode((m) => !m)}
-          className='p-2 border rounded text-sm'
+          className='p-2 border rounded-full text-sm hover:bg-primary/10 transition'
         >
           {manualMode ? t('picker') : t('manual')}
         </button>
@@ -139,7 +139,7 @@ export default function EventForm({
           {events.map((event) => (
             <li
               key={event.id}
-              className='p-4 bg-background border border-primary/10 rounded-lg shadow-sm'
+              className='p-4 bg-background/60 border border-primary/10 rounded-lg shadow-sm transition hover:shadow-md'
             >
               <div className='flex justify-between'>
                 <div className='space-y-1'>
@@ -171,7 +171,7 @@ export default function EventForm({
                 </div>
                 <button
                   onClick={() => onRemove(event.id)}
-                  className='text-sm text-red-500 hover:text-red-700'
+                  className='text-sm text-red-500 hover:text-red-700 transition'
                 >
                   {t('delete')}
                 </button>

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -18,7 +18,7 @@ export default function LocaleSwitcher() {
     <select
       value={currentLocale}
       onChange={handleChange}
-      className='p-2 border rounded text-sm'
+      className='p-2 border rounded-full text-sm bg-background text-foreground hover:bg-primary/10 transition'
     >
       <option value='ko'>한국어</option>
       <option value='en'>English</option>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -15,7 +15,10 @@ export default function ThemeToggle() {
   };
 
   return (
-    <button onClick={toggleTheme} className="p-2 border rounded text-sm">
+    <button
+      onClick={toggleTheme}
+      className="p-2 border rounded-full text-sm hover:bg-primary/10 transition"
+    >
       {theme === 'dark' ? 'Light' : 'Dark'}
     </button>
   );


### PR DESCRIPTION
## Summary
- refresh home page with gradient background, card layout and subtle fade-in animation
- polish form, buttons and toggles with rounded styling and transitions
- enhance event list cards for a cleaner mobile-friendly experience

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cadb0356883259f7d60995620f8ce