### PR TITLE
refactor: extract event list component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import EventForm from '@/components/EventForm';
 import DownloadButton from '@/components/DownloadButton';
+import EventList from '@/components/EventList';
 import { useState } from 'react';
 import { CalendarEvent } from '@/lib/icsGenerator';
 import { useTranslations } from 'next-intl';
@@ -20,24 +21,27 @@ export default function HomePage() {
 
   return (
     <main className='min-h-screen bg-gradient-to-br from-background to-primary/10 text-foreground px-4 py-10 transition-colors flex items-center justify-center'>
-      <div className='w-full max-w-2xl space-y-8 text-center animate-fade-in'>
-        <h1 className='text-3xl md:text-5xl font-bold'>{`📅 ${t('title')}`}</h1>
-        <p className='text-sm md:text-base opacity-80'>
-          Create a calendar file (.ics) for your events. Supports English,
-          日本語 & 한국어.
-        </p>
+      <div className='w-full max-w-4xl space-y-8 animate-fade-in'>
+        <div className='text-center space-y-2'>
+          <h1 className='text-3xl md:text-5xl font-bold'>{`📅 ${t('title')}`}</h1>
+          <p className='text-sm md:text-base opacity-80'>
+            Create a calendar file (.ics) for your events. Supports English,
+            日本語 & 한국어.
+          </p>
+        </div>
 
-        <EventForm
-          onAdd={handleAdd}
-          onRemove={handleRemove}
-          events={events}
-        />
+        <div className='flex flex-col md:flex-row gap-8 md:items-start'>
+          <EventForm onAdd={handleAdd} />
+          <EventList events={events} onRemove={handleRemove} />
+        </div>
+
         <DownloadButton events={events} />
 
-        <footer className='pt-6 text-xs opacity-60'>
+        <footer className='pt-6 text-xs opacity-60 text-center'>
           Made by Yunsu Bae - 다국어 지원 테스트 중
         </footer>
       </div>
     </main>
   );
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,9 @@ import { useTranslations } from 'next-intl';
 
 export default function HomePage() {
   const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [showEvents, setShowEvents] = useState(false);
   const t = useTranslations('Home');
+  const formT = useTranslations('EventForm');
 
   const handleAdd = (event: CalendarEvent) => {
     setEvents((prev) => [...prev, event]);
@@ -32,8 +34,38 @@ export default function HomePage() {
 
         <div className='flex flex-col md:flex-row gap-8 md:items-start'>
           <EventForm onAdd={handleAdd} />
-          <EventList events={events} onRemove={handleRemove} />
+          <EventList
+            events={events}
+            onRemove={handleRemove}
+            className='hidden md:block'
+          />
         </div>
+
+        {events.length > 0 && (
+          <div className='fixed bottom-4 left-0 right-0 flex justify-center md:hidden'>
+            <div className='relative w-full max-w-md'>
+              <div
+                className={`absolute bottom-full mb-2 w-full transition-all duration-300 ${
+                  showEvents
+                    ? 'translate-y-0 opacity-100'
+                    : 'translate-y-full opacity-0 pointer-events-none'
+                }`}
+              >
+                <EventList
+                  events={events}
+                  onRemove={handleRemove}
+                  listClassName='max-h-60 overflow-y-auto'
+                />
+              </div>
+              <button
+                onClick={() => setShowEvents((s) => !s)}
+                className='card px-4 py-2 text-sm shadow-md w-full'
+              >
+                {formT('events')} ({events.length})
+              </button>
+            </div>
+          </div>
+        )}
 
         <DownloadButton events={events} />
 

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -8,13 +8,9 @@ import KeyboardDateTimeInput from './KeyboardDateTimeInput';
 import { useTranslations } from 'next-intl';
 
 export default function EventForm({
-  onAdd,
-  onRemove,
-  events
+  onAdd
 }: {
   onAdd: (event: CalendarEvent) => void;
-  onRemove: (id: string) => void;
-  events: CalendarEvent[];
 }) {
   const t = useTranslations('EventForm');
   const [title, setTitle] = useState('');
@@ -33,10 +29,6 @@ export default function EventForm({
   const [phone, setPhone] = useState('');
   const [url, setUrl] = useState('');
   const [manualMode, setManualMode] = useState(false);
-  const [showEvents, setShowEvents] = useState(false);
-
-  const formatDateTime = (value: string) =>
-    new Date(value).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
 
   const handleSubmit = () => {
     if (!title || !start || !end) return;
@@ -60,17 +52,16 @@ export default function EventForm({
   };
 
   return (
-    <>
-      <div className='card p-6 sm:p-8 space-y-6 animate-fade-in'>
-        <div className='flex justify-end'>
-          <button
-            onClick={() => setManualMode((m) => !m)}
-            className='p-2 border rounded-full text-sm hover:bg-primary/10 transition'
-          >
-            {manualMode ? t('picker') : t('manual')}
-          </button>
-        </div>
-        <div className='space-y-4'>
+    <div className='card p-6 sm:p-8 space-y-6 animate-fade-in w-full md:w-1/2'>
+      <div className='flex justify-end'>
+        <button
+          onClick={() => setManualMode((m) => !m)}
+          className='p-2 border rounded-full text-sm hover:bg-primary/10 transition'
+        >
+          {manualMode ? t('picker') : t('manual')}
+        </button>
+      </div>
+      <div className='space-y-4'>
         <div className='flex flex-col w-full max-w-sm'>
           <label className='text-sm font-medium mb-1'>{t('title')}</label>
           <input
@@ -136,66 +127,7 @@ export default function EventForm({
       <button onClick={handleSubmit} className='btn w-full'>
         {t('add')}
       </button>
-      </div>
-      {events.length > 0 && (
-        <div className='fixed bottom-4 left-0 right-0 flex justify-center'>
-          <div className='relative'>
-            {showEvents && (
-              <ul className='absolute bottom-full mb-2 w-72 sm:w-80 max-h-60 overflow-y-auto space-y-2'>
-                {events.map((event) => (
-                  <li
-                    key={event.id}
-                    className='p-4 bg-background/60 border border-primary/10 rounded-lg shadow-sm transition hover:shadow-md'
-                  >
-                    <div className='flex justify-between'>
-                      <div className='space-y-1'>
-                        <div className='font-semibold'>{event.title}</div>
-                        <div className='text-sm'>
-                          {t('start')}: {formatDateTime(event.start)}<br />
-                          {t('end')}: {formatDateTime(event.end)}
-                        </div>
-                        {event.location && (
-                          <div className='text-sm'>
-                            {t('location')}: {event.location}
-                          </div>
-                        )}
-                        {event.description && (
-                          <div className='text-sm'>
-                            {t('description')}: {event.description}
-                          </div>
-                        )}
-                        {event.phone && (
-                          <div className='text-sm'>
-                            {t('phone')}: {event.phone}
-                          </div>
-                        )}
-                        {event.url && (
-                          <div className='text-sm break-all'>
-                            {t('url')}: <a href={event.url} className='text-primary underline'>{event.url}</a>
-                          </div>
-                        )}
-                      </div>
-                      <button
-                        onClick={() => onRemove(event.id)}
-                        className='text-sm text-red-500 hover:text-red-700 transition'
-                      >
-                        {t('delete')}
-                      </button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <button
-              onClick={() => setShowEvents((s) => !s)}
-              className='card px-4 py-2 text-sm shadow-md w-72 sm:w-80'
-            >
-              {t('events')} ({events.length})
-            </button>
-          </div>
-        </div>
-      )}
-    </>
+    </div>
   );
 }
 

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { CalendarEvent } from '@/lib/icsGenerator';
+import { useTranslations } from 'next-intl';
+
+interface EventListProps {
+  events: CalendarEvent[];
+  onRemove: (id: string) => void;
+}
+
+export default function EventList({ events, onRemove }: EventListProps) {
+  const t = useTranslations('EventForm');
+  const formatDateTime = (value: string) =>
+    new Date(value).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
+
+  if (events.length === 0) return null;
+
+  return (
+    <div className='card p-6 sm:p-8 space-y-4 w-full md:w-1/2 animate-fade-in'>
+      <h2 className='text-lg font-semibold'>{t('events')} ({events.length})</h2>
+      <ul className='space-y-2 text-left'>
+        {events.map((event) => (
+          <li
+            key={event.id}
+            className='p-4 bg-background/60 border border-primary/10 rounded-lg shadow-sm transition hover:shadow-md'
+          >
+            <div className='flex justify-between'>
+              <div className='space-y-1'>
+                <div className='font-semibold'>{event.title}</div>
+                <div className='text-sm'>
+                  {t('start')}: {formatDateTime(event.start)}<br />
+                  {t('end')}: {formatDateTime(event.end)}
+                </div>
+                {event.location && (
+                  <div className='text-sm'>{t('location')}: {event.location}</div>
+                )}
+                {event.description && (
+                  <div className='text-sm'>{t('description')}: {event.description}</div>
+                )}
+                {event.phone && (
+                  <div className='text-sm'>{t('phone')}: {event.phone}</div>
+                )}
+                {event.url && (
+                  <div className='text-sm break-all'>
+                    {t('url')}: <a href={event.url} className='text-primary underline'>{event.url}</a>
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={() => onRemove(event.id)}
+                className='text-sm text-red-500 hover:text-red-700 transition'
+              >
+                {t('delete')}
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -6,9 +6,16 @@ import { useTranslations } from 'next-intl';
 interface EventListProps {
   events: CalendarEvent[];
   onRemove: (id: string) => void;
+  className?: string;
+  listClassName?: string;
 }
 
-export default function EventList({ events, onRemove }: EventListProps) {
+export default function EventList({
+  events,
+  onRemove,
+  className = '',
+  listClassName = ''
+}: EventListProps) {
   const t = useTranslations('EventForm');
   const formatDateTime = (value: string) =>
     new Date(value).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
@@ -16,9 +23,9 @@ export default function EventList({ events, onRemove }: EventListProps) {
   if (events.length === 0) return null;
 
   return (
-    <div className='card p-6 sm:p-8 space-y-4 w-full md:w-1/2 animate-fade-in'>
+    <div className={`card p-6 sm:p-8 space-y-4 w-full md:w-1/2 animate-fade-in ${className}`}>
       <h2 className='text-lg font-semibold'>{t('events')} ({events.length})</h2>
-      <ul className='space-y-2 text-left'>
+      <ul className={`space-y-2 text-left ${listClassName}`}>
         {events.map((event) => (
           <li
             key={event.id}


### PR DESCRIPTION
## Summary
- factor out event listing into dedicated component
- align event list beside form on desktop and below on mobile

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ef56caafc8325818aced44b532c7b