### PR TITLE
feat: add logo component

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,7 +45,7 @@ body {
 }
 
 .input {
-  @apply border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 w-full text-sm bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 transition;
+  @apply border border-primary/20 rounded-lg px-3 py-2 w-full text-sm bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 transition bg-gradient-to-bl from-background to-primary/5;
 }
 
 .btn {
@@ -53,5 +53,9 @@ body {
 }
 
 .card {
-  @apply bg-background/80 backdrop-blur border border-primary/20 rounded-2xl shadow-lg;
+  @apply bg-background/80 backdrop-blur border border-primary/20 rounded-2xl shadow-lg shadow-primary/10;
+}
+
+.shadow {
+  @apply shadow-md shadow-primary/10;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import LocaleSwitcher from '@/components/LocaleSwitcher';
 import ThemeProvider from '@/components/ThemeProvider';
 import ThemeToggle from '@/components/ThemeToggle';
 import TutorialModal from '@/components/TutorialModal';
+import Logo from '@/components/Logo';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -69,14 +70,17 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`min-h-screen ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider>
           <NextIntlClientProvider>
-            <div className='flex justify-end gap-2 p-4'>
-              <TutorialModal />
-              <LocaleSwitcher />
-              <ThemeToggle />
+            <div className='flex justify-between gap-2 p-4 sticky top-0 z-10 backdrop-blur bg-gradient-to-br from-background to-primary/5'>
+              <Logo />
+              <div className='flex justify-end gap-2'>
+                <TutorialModal />
+                <LocaleSwitcher />
+                <ThemeToggle />
+              </div>
             </div>
             {children}
           </NextIntlClientProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,17 +22,19 @@ export default function HomePage() {
   };
 
   return (
-    <main className='min-h-screen bg-gradient-to-br from-background to-primary/10 text-foreground px-4 py-10 transition-colors flex items-center justify-center'>
+    <main className='p-4 bg-gradient-to-br from-background to-primary/10 text-foreground transition-colors flex items-center justify-center'>
       <div className='w-full max-w-4xl space-y-8 animate-fade-in'>
         <div className='text-center space-y-2'>
-          <h1 className='text-3xl md:text-5xl font-bold'>{`📅 ${t('title')}`}</h1>
+          <h1 className='text-3xl md:text-5xl font-bold'>{`📅 ${t(
+            'title'
+          )}`}</h1>
           <p className='text-sm md:text-base opacity-80'>
             Create a calendar file (.ics) for your events. Supports English,
             日本語 & 한국어.
           </p>
         </div>
 
-        <div className='flex flex-col md:flex-row gap-8 md:items-start'>
+        <div className='flex flex-col justify-center md:flex-row gap-8 md:items-start'>
           <EventForm onAdd={handleAdd} />
           <EventList
             events={events}
@@ -48,7 +50,7 @@ export default function HomePage() {
                 className={`absolute bottom-full mb-2 w-full transition-all duration-300 ${
                   showEvents
                     ? 'translate-y-0 opacity-100'
-                    : 'translate-y-full opacity-0 pointer-events-none'
+                    : 'translate-y-1/7 opacity-0 pointer-events-none'
                 }`}
               >
                 <EventList
@@ -59,7 +61,7 @@ export default function HomePage() {
               </div>
               <button
                 onClick={() => setShowEvents((s) => !s)}
-                className='card px-4 py-2 text-sm shadow-md w-full'
+                className='card px-4 py-2 text-sm shadow w-full'
               >
                 {formT('events')} ({events.length})
               </button>
@@ -76,4 +78,3 @@ export default function HomePage() {
     </main>
   );
 }
-

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -20,7 +20,7 @@ export default function DownloadButton({ events }: Props) {
       <button
         onClick={handleDownload}
         disabled={events.length === 0}
-        className='btn rounded-full px-6 py-3 text-sm md:text-base shadow-md hover:shadow-lg transition disabled:opacity-50'
+        className='btn rounded-full px-6 py-3 text-sm md:text-base shadow hover:shadow-lg transition disabled:opacity-50'
       >
         Download Calendar
       </button>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -52,7 +52,7 @@ export default function EventForm({
   };
 
   return (
-    <div className='card p-6 sm:p-8 space-y-6 animate-fade-in w-full md:w-1/2'>
+    <div className='card bg-gradient-to-br from-background to-primary/10 p-6 sm:p-8 space-y-6 animate-fade-in w-full md:w-1/2'>
       <div className='flex justify-end'>
         <button
           onClick={() => setManualMode((m) => !m)}
@@ -73,8 +73,16 @@ export default function EventForm({
         </div>
         {manualMode ? (
           <div className='space-y-4'>
-            <KeyboardDateTimeInput label={t('start')} value={start} onChange={setStart} />
-            <KeyboardDateTimeInput label={t('end')} value={end} onChange={setEnd} />
+            <KeyboardDateTimeInput
+              label={t('start')}
+              value={start}
+              onChange={setStart}
+            />
+            <KeyboardDateTimeInput
+              label={t('end')}
+              value={end}
+              onChange={setEnd}
+            />
           </div>
         ) : (
           <DateTimeInput
@@ -130,4 +138,3 @@ export default function EventForm({
     </div>
   );
 }
-

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -18,38 +18,55 @@ export default function EventList({
 }: EventListProps) {
   const t = useTranslations('EventForm');
   const formatDateTime = (value: string) =>
-    new Date(value).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
+    new Date(value).toLocaleString([], {
+      dateStyle: 'short',
+      timeStyle: 'short'
+    });
 
   if (events.length === 0) return null;
 
   return (
-    <div className={`card p-6 sm:p-8 space-y-4 w-full md:w-1/2 animate-fade-in ${className}`}>
-      <h2 className='text-lg font-semibold'>{t('events')} ({events.length})</h2>
-      <ul className={`space-y-2 text-left ${listClassName}`}>
+    <div
+      className={`card bg-gradient-to-br from-background to-primary/10 p-2 sm:p-8 w-full md:w-1/2 animate-fade-in ${className}`}
+    >
+      <h2 className='text-lg font-semibold px-4 py-2'>
+        {t('events')} ({events.length})
+      </h2>
+      <ul className={`space-y-2 text-left p-4 ${listClassName}`}>
         {events.map((event) => (
           <li
             key={event.id}
-            className='p-4 bg-background/60 border border-primary/10 rounded-lg shadow-sm transition hover:shadow-md'
+            className='bg-gradient-to-bl from-background to-primary/5 bg-background/80 backdrop-blur border border-primary/20 rounded-2xl p-4 shadow-sm transition hover:shadow-md shadow-primary/10'
           >
             <div className='flex justify-between'>
               <div className='space-y-1'>
                 <div className='font-semibold'>{event.title}</div>
                 <div className='text-sm'>
-                  {t('start')}: {formatDateTime(event.start)}<br />
+                  {t('start')}: {formatDateTime(event.start)}
+                  <br />
                   {t('end')}: {formatDateTime(event.end)}
                 </div>
                 {event.location && (
-                  <div className='text-sm'>{t('location')}: {event.location}</div>
+                  <div className='text-sm'>
+                    {t('location')}: {event.location}
+                  </div>
                 )}
                 {event.description && (
-                  <div className='text-sm'>{t('description')}: {event.description}</div>
+                  <div className='text-sm'>
+                    {t('description')}: {event.description}
+                  </div>
                 )}
                 {event.phone && (
-                  <div className='text-sm'>{t('phone')}: {event.phone}</div>
+                  <div className='text-sm'>
+                    {t('phone')}: {event.phone}
+                  </div>
                 )}
                 {event.url && (
                   <div className='text-sm break-all'>
-                    {t('url')}: <a href={event.url} className='text-primary underline'>{event.url}</a>
+                    {t('url')}:{' '}
+                    <a href={event.url} className='text-primary underline'>
+                      {event.url}
+                    </a>
                   </div>
                 )}
               </div>
@@ -66,4 +83,3 @@ export default function EventList({
     </div>
   );
 }
-

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -15,7 +15,10 @@ interface LogoProps {
   direction?: 'horizontal' | 'vertical';
 }
 
-export default function Logo({ size = 40, direction = 'horizontal' }: LogoProps) {
+export default function Logo({
+  size = 40,
+  direction = 'horizontal'
+}: LogoProps) {
   const t = useTranslations('Home');
   const title = t('title');
 
@@ -24,14 +27,14 @@ export default function Logo({ size = 40, direction = 'horizontal' }: LogoProps)
   return (
     <div className={`flex ${flexDirection} items-center gap-2`}>
       <Image
-        src="/logo_sukegene.png"
+        src='/logo_sukegene.png'
         alt={title}
         width={size}
         height={size}
         priority
       />
       <span
-        className="font-bold text-foreground"
+        className='text-foreground font-bold'
         style={{ fontSize: size * 0.5 }}
       >
         {title}
@@ -39,4 +42,3 @@ export default function Logo({ size = 40, direction = 'horizontal' }: LogoProps)
     </div>
   );
 }
-

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -12,7 +12,7 @@ export default function Toast({ message, onClose }: ToastProps) {
   }, [onClose]);
 
   return (
-    <div className="fixed bottom-4 right-4 bg-red-500 text-white px-4 py-2 rounded shadow-lg dark:bg-red-600">
+    <div className='fixed bottom-4 right-4 bg-red-500 text-white px-4 py-2 rounded shadow-lg dark:bg-red-600 shadow-primary/10'>
       {message}
     </div>
   );

--- a/src/components/TutorialModal.tsx
+++ b/src/components/TutorialModal.tsx
@@ -16,7 +16,10 @@ export default function TutorialModal() {
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
-    const seen = typeof window !== 'undefined' ? localStorage.getItem('tutorialSeen') : 'true';
+    const seen =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('tutorialSeen')
+        : 'true';
     if (!seen) {
       setOpen(true);
     }
@@ -42,43 +45,43 @@ export default function TutorialModal() {
           setIndex(0);
           setOpen(true);
         }}
-        className="p-2 border rounded-full text-sm hover:bg-primary/10 transition"
+        className='p-2 border rounded-full text-sm hover:bg-primary/10 transition'
       >
         ?
       </button>
       {open && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full text-center">
-            <div className="overflow-hidden mb-4">
+        <div className='fixed inset-0 bg-black/50 flex items-center justify-center z-50'>
+          <div className='bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full text-center shadow-primary/10'>
+            <div className='overflow-hidden mb-4'>
               <div
-                className="flex transition-transform duration-500"
+                className='flex transition-transform duration-500'
                 style={{ transform: `translateX(-${index * 100}%)` }}
               >
                 {slides.map((slide, i) => (
-                  <div key={i} className="w-full flex-shrink-0">
+                  <div key={i} className='w-full flex-shrink-0'>
                     <Image
                       src={slide.src}
                       alt={slide.text}
                       width={80}
                       height={80}
-                      className="mx-auto mb-2"
+                      className='mx-auto mb-2'
                     />
                     <p>{slide.text}</p>
                   </div>
                 ))}
               </div>
             </div>
-            <div className="flex justify-between items-center">
-              <span className="text-sm">
+            <div className='flex justify-between items-center'>
+              <span className='text-sm'>
                 {index + 1} / {slides.length}
               </span>
-              <button onClick={next} className="px-2 py-1 border rounded">
+              <button onClick={next} className='px-2 py-1 border rounded'>
                 {t('next')}
               </button>
             </div>
             <button
               onClick={close}
-              className="mt-4 px-3 py-1 border rounded w-full"
+              className='mt-4 px-3 py-1 border rounded w-full'
             >
               {t('close')}
             </button>
@@ -88,4 +91,3 @@ export default function TutorialModal() {
     </>
   );
 }
-


### PR DESCRIPTION
## Summary
- add a reusable Logo component with adjustable size, direction and i18n-aware text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f4bec9a1c83258194711d9ce8a664